### PR TITLE
Fixing queue tests

### DIFF
--- a/src/lib/transfer_manager.ts
+++ b/src/lib/transfer_manager.ts
@@ -17,7 +17,7 @@ export class TransferManager extends events.EventEmitter {
     private client: EDMConnection;
     private method: TransferMethod;
 
-    constructor(queue: TransferQueue) {
+    constructor(queue_id: string) {
         super();
 
         this.concurrency = settings.conf.appSettings.maxAsyncTransfers;
@@ -28,7 +28,7 @@ export class TransferManager extends events.EventEmitter {
                 settings.conf.serverSettings.token);
         }
 
-        this.queue = queue;
+        this.queue = new TransferQueue(queue_id);
 
         // We must pass this lambda as the event callback, rather than the
         // bare class method, otherwise the context of 'this' will be wrong in the

--- a/src/lib/transfer_queue.ts
+++ b/src/lib/transfer_queue.ts
@@ -10,9 +10,6 @@ import * as _ from "lodash";
 import {settings} from './settings';
 import {TransferManager} from "./transfer_manager";
 
-const queues = {};
-const managers = {};
-
 /*
  stream.Duplex events:
  * 'readable' - when the readability state changes (new data becomes available, or stream becomes empty)
@@ -94,20 +91,19 @@ export class TransferQueue extends stream.Duplex {
 }
 
 export class TransferQueuePoolManager {
+    managers = {};
+
     getQueue(queue_id: string): TransferQueue {
-        if (queues[queue_id] == null) {
-            queues[queue_id] = new TransferQueue(queue_id);
+        if (this.managers[queue_id] == null) {
+            this.managers[queue_id] = new TransferManager(queue_id);
         }
-        if (managers[queue_id] == null) {
-            managers[queue_id] = new TransferManager(queues[queue_id]);
-        }
-        return queues[queue_id];
+        return this.managers[queue_id].queue;
     }
 
-    _getManager(queue_id: string): TransferManager {
+    getManager(queue_id: string): TransferManager {
         // ensure queue (and associated manager) is created
         this.getQueue(queue_id);
-        return managers[queue_id];
+        return this.managers[queue_id];
     }
 
     createTransferJob(source: EDMSource,

--- a/src/test/test_transfer_method.ts
+++ b/src/test/test_transfer_method.ts
@@ -9,8 +9,8 @@ describe("A transfer method ", function () {
 
 
     it("can show progress using the example 'dummy' transfer method", function (done) {
+        this.timeout(5000);
         let file_transfer_id = "a-file-transfer-uuid";
-
         function logProgress(id: string, bytes: number) {
             console.info(`${id}: ${bytes} bytes`)
         }

--- a/src/test/test_transfer_queue.ts
+++ b/src/test/test_transfer_queue.ts
@@ -12,6 +12,8 @@ import EDMFile from "../lib/file_tracking"
 import {EDMFileCache} from "../lib/cache";
 import {DummyTransfer} from "../lib/transfer_methods/dummy_transfer";
 
+var eventDebug = require('event-debug');
+
 describe("The transfer queue ", function () {
     let host: EDMDestinationHost;
     let destination: EDMDestination;
@@ -204,7 +206,6 @@ describe("The transfer queue ", function () {
     });
 
     it("should add a file to the transfer queue when it has pending file transfers", function (done) {
-        setupSettings();
 
         let now = Math.floor(Date.now() / 1000);
 
@@ -226,8 +227,8 @@ describe("The transfer queue ", function () {
             transfers: [transferRecord],
         } as EDMCachedFile;
 
-        let tq = TransferQueuePool.getQueue(destination.id);
-        let manager = TransferQueuePool._getManager(destination.id);
+        let manager = TransferQueuePool.getManager(destination.id);
+        let tq = manager.queue;
 
         tq.on('readable', () => {
             console.log(`Queue ${tq.queue_id} became readable`);
@@ -244,9 +245,9 @@ describe("The transfer queue ", function () {
             // done();
         });
 
-
         // TODO: Never fires ?
         manager.on('transfer_complete', (transfer_id, bytes) => {
+            console.log('done never fires');
             done();
         });
 

--- a/src/test/test_transfer_queue.ts
+++ b/src/test/test_transfer_queue.ts
@@ -247,7 +247,7 @@ describe("The transfer queue ", function () {
 
         // TODO: Never fires ?
         manager.on('transfer_complete', (transfer_id, bytes) => {
-            console.log('done never fires');
+            console.info(`Transfer ${transfer_id} of ${bytes} bytes completed`);
             done();
         });
 


### PR DESCRIPTION
Running `setupSettings();` twice caused this issue. The event was firing alright, just on a different manager.
The other changes are just a bit of cleanup I thought might be useful for debugging before I found the solution.